### PR TITLE
[BUGFIX] Return relative path where it is expected

### DIFF
--- a/Classes/Utility/GeneralUtility.php
+++ b/Classes/Utility/GeneralUtility.php
@@ -685,7 +685,7 @@ class GeneralUtility implements SingletonInterface
         }
         $path = explode('/', $path);
         if (strpos($path[0], 'EXT') === 0) {
-            return \TYPO3\CMS\Core\Utility\GeneralUtility::getFileAbsFileName(implode('/', $path));
+            return PathUtility::getPublicResourceWebPath(implode('/', $path), false);
         }
         $path = implode('/', $path);
         $path = str_replace('//', '/', $path);


### PR DESCRIPTION
The comment above the method states that it should return "the relative path from site root"

`getFileAbsFileName()` returns the absolute path on the file system.
The absolute path works for internally read files, e. g. templates, but is also used for included JS files in the frontend, where it needs to be relative.