### PR TITLE
fix: Pass Extbase settings to implementation

### DIFF
--- a/Classes/Controller/Dispatcher.php
+++ b/Classes/Controller/Dispatcher.php
@@ -47,7 +47,7 @@ class Dispatcher extends AbstractPlugin
      */
     protected $utilityFuncs;
 
-    public function main(): ResponseInterface
+    public function main(array $settings): ResponseInterface
     {
         $this->componentManager = GeneralUtility::makeInstance(Manager::class);
         $this->globals = GeneralUtility::makeInstance(Globals::class);
@@ -87,7 +87,7 @@ class Dispatcher extends AbstractPlugin
             $controller->setPredefined($predef);
         }
 
-        $result = $controller->process();
+        $result = $controller->process($settings);
         return $result;
     }
 }

--- a/Classes/Controller/FormController.php
+++ b/Classes/Controller/FormController.php
@@ -48,6 +48,7 @@ class FormController extends AbstractClass
     protected ?Configuration $configuration = null;
     protected ResponseFactory $responseFactory;
     protected StreamFactory $streamFactory;
+    protected array $processSettings = [];
 
     public function __construct()
     {
@@ -57,8 +58,9 @@ class FormController extends AbstractClass
 
     }
 
-    public function process(): ResponseInterface
+    public function process(array $settings): ResponseInterface
     {
+        $this->processSettings = $settings;
         $this->init();
         $this->storeFileNamesInGP();
         $this->processFileRemoval();
@@ -973,6 +975,7 @@ class FormController extends AbstractClass
             unset($settings['predef.']);
             $settings = $this->utilityFuncs->mergeConfiguration($settings, $predefSettings);
         }
+        $settings = $this->utilityFuncs->mergeConfiguration($settings, $this->processSettings);
         return $settings;
     }
 }

--- a/Classes/Controller/FormhandlerPluginController.php
+++ b/Classes/Controller/FormhandlerPluginController.php
@@ -3,6 +3,8 @@
 namespace Typoheads\Formhandler\Controller;
 
 use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Core\TypoScript\TypoScriptService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
 class FormhandlerPluginController extends ActionController
@@ -11,7 +13,9 @@ class FormhandlerPluginController extends ActionController
     {
         $dispatcher = new Dispatcher();
         $dispatcher->setRequests($this->request);
-        return $dispatcher->main('', []);
+        $typoscript = GeneralUtility::makeInstance(TypoScriptService::class);
+        $settings = $typoscript->convertPlainArrayToTypoScriptArray($this->settings);
+        return $dispatcher->main($settings);
     }
 
 }


### PR DESCRIPTION
Previously, when integrating Formhandler through TypoScript, the settings were not used:

```
lib.Foo = EXTBASEPLUGIN
lib.Foo {
  extensioName = Formhandler
  plugin = Pi1
  settings {
   # These settings get ignored
   ...
  }
}
```

This change passes the settings along and merges them with other configuration. It's accessing the internal TypoScriptService class to emulate old behaviour. It is not deeply tested yet, but might suffice.

(I am not sure about the current state and roadmap of this repository yet, but most things seem to work, apart from the now missing IsInDBTable, which I can restore)